### PR TITLE
Non-Admin-Reroute

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,10 +1,15 @@
 <script setup lang="ts">
   import { authClient } from './utils/auth-client'
+  import { computed, watch } from 'vue'
 
   //Auth Setup
   const sessionResult = authClient.useSession()
   const session = computed(() => sessionResult.value?.data ?? null)
   const route = useRoute()
+
+  watch(session, (newSession) => {
+    if (!newSession && route.path !== '/auth') navigateTo('/auth')
+  })
 
   //Logic for information to display in user info
   const displayUser = computed(() => {
@@ -56,7 +61,7 @@
                 <span class="text-sm font-semibold text-white">{{ displayUser.initials }}</span>
               </div>
               <div class="text-right">
-                <p class="text-sm font-medium text-gray-700">{{ displayUser.name }}</p>
+                <p class="font-mediumg text-sm text-gray-700">{{ displayUser.name }}</p>
                 <p class="text-[10px] font-semibold tracking-wider text-[#8DC63F] uppercase">
                   {{ displayUser.role }}
                 </p>

--- a/app/app.vue
+++ b/app/app.vue
@@ -47,7 +47,10 @@
           </div>
 
           <!-- Need to be valid user and it needs to be on index -->
-          <div v-if="displayUser && route.path === '/'" class="flex items-center gap-4">
+          <div
+            v-if="displayUser && (route.path === '/' || route.path === '/dashboard')"
+            class="flex items-center gap-4"
+          >
             <div class="flex items-center gap-2">
               <div class="flex h-8 w-8 items-center justify-center rounded-full bg-[#0077C0]">
                 <span class="text-sm font-semibold text-white">{{ displayUser.initials }}</span>

--- a/app/middleware/auth.global.ts
+++ b/app/middleware/auth.global.ts
@@ -1,7 +1,9 @@
+import { user } from '#build/ui'
 import { authClient } from '../utils/auth-client'
 
 export default defineNuxtRouteMiddleware(async (to) => {
   const { data: session } = await authClient.useSession(useFetch)
+  const currentuser = session.value?.user as { role?: string } | undefined
 
   if (session.value) {
     if (to.path === '/auth') {
@@ -10,6 +12,11 @@ export default defineNuxtRouteMiddleware(async (to) => {
   } else {
     if (to.path !== '/auth') {
       return navigateTo('/auth')
+    }
+  }
+  if (currentuser !== undefined) {
+    if (to.path.startsWith('/dashboard') && currentuser.role !== 'ADMIN') {
+      return navigateTo('/')
     }
   }
 })

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -1,31 +1,41 @@
-import { betterAuth } from "better-auth";
-import { prismaAdapter } from "better-auth/adapters/prisma";
-import { prisma } from "./prisma"
-import { emailOTP } from "better-auth/plugins/email-otp"
-import nodemailer from "nodemailer"
+import { betterAuth } from 'better-auth'
+import { prismaAdapter } from 'better-auth/adapters/prisma'
+import { prisma } from './prisma'
+import { emailOTP } from 'better-auth/plugins/email-otp'
+import nodemailer from 'nodemailer'
+import { prismaVersion } from '~~/prisma/generated/internal/prismaNamespace'
 
 const transporter = nodemailer.createTransport({
-	service: "gmail",
-	auth: {
-		user: process.env.EMAIL_USER,
-		pass: process.env.EMAIL_PASS,
-	}
+  service: 'gmail',
+  auth: {
+    user: process.env.EMAIL_USER,
+    pass: process.env.EMAIL_PASS,
+  },
 })
 
 export const auth = betterAuth({
-	database: prismaAdapter(prisma, {
-		provider: "sqlite",
-	}),
-	plugins: [
-		emailOTP({
-			async sendVerificationOTP({ email, otp, type }) {
-				await transporter.sendMail({
-					from: process.env.EMAIL_USER,
-					to: email,
-					subject: "OTP",
-					html: `${otp}`,
-				})
-			}
-		})
-	]
-});
+  database: prismaAdapter(prisma, {
+    provider: 'sqlite',
+  }),
+
+  user: {
+    additionalFields: {
+      role: {
+        type: 'string',
+      },
+    },
+  },
+
+  plugins: [
+    emailOTP({
+      async sendVerificationOTP({ email, otp }) {
+        await transporter.sendMail({
+          from: process.env.EMAIL_USER,
+          to: email,
+          subject: 'OTP',
+          html: `${otp}`,
+        })
+      },
+    }),
+  ],
+})


### PR DESCRIPTION
This PR updates the authentication and UI logic to ensure that only users with an admin role (as stored in Prisma and retrieved through BetterAuth) can access the admin dashboard. It also fixes an issue where the site header was not rendering on admin pages.

Changes:
- Added a "additionalFields" that includes role to a user object in auth.ts so the BetterAuth can recognize it as a field that it needs to see when making a session.
- Added a currentUser variable that has the role when the session starts and made code to where if the currentUser's role isn't ADMIN, they can't get into the user dashboard.
- Fixed a minor bug where the website header wasn't appearing on dashboard due to a lack of a v-if route.path to the dashboard in app.vue.

