### PR TITLE
Made it so netIDs are lowercased after added

### DIFF
--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -68,6 +68,7 @@
     try {
       const results = await Promise.all(
         validIds.map(async (id) => {
+          id = id.toLowerCase()
           const res = await fetch('/api/users', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
Made it so when netIDs are entered, if they are by any chance capitalized or not lowercased, they are lowercased to prevent duplicate users from being made.